### PR TITLE
Update to latest http-verbs version

### DIFF
--- a/project/HmrcBuild.scala
+++ b/project/HmrcBuild.scala
@@ -50,7 +50,7 @@ object Dependencies {
     "com.typesafe.play" %% "play-json" % PlayVersion.current % "provided",
     "com.typesafe.play" %% "play-datacommons" % PlayVersion.current % "provided",
     "uk.gov.hmrc" %% "json-encryption" % "2.0.0",
-    "uk.gov.hmrc" %% "http-verbs" % "3.3.0"
+    "uk.gov.hmrc" %% "http-verbs" % "4.0.0"
   )
 
   val test = Seq(


### PR DESCRIPTION
After updates to http-verbs, it is necessary for downstream libraries to update dependency version
